### PR TITLE
Default ports were switched

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 
         // Change to the port you're using
         $.ajax({
-          url: "http://localhost:3001/api/appointments",
+          url: "http://localhost:3002/api/appointments",
           method: "GET",
           headers: { "Authorization": "Bearer " + access_token },
           success: function (data) {
@@ -61,7 +61,7 @@
 
         // Change to the port you're using
         $.ajax({
-          url: "http://localhost:3002/api/contacts",
+          url: "http://localhost:3001/api/contacts",
           method: "GET",
           headers: { "Authorization": "Bearer " + access_token },
           success: function (data) {


### PR DESCRIPTION
The default contacts api port in .env was 3002, but in index.html it was 3001.
The default appointments api port in .env was 3001, but in index.html it was 3002.

This caused me to lose some time debugging trying to see why the project would not work correctly after adding my auth0 domain.